### PR TITLE
Added artifact upload and download steps in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,23 @@ jobs:
         run: |
           poetry build
 
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
   pypi-publish:
+    needs: package_build
     name: upload release to PyPI
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11


### PR DESCRIPTION
Introduced steps to both upload and download build artifacts during the package building and PyPI publishing stages respectively in Github Actions workflow. This ensures the correct built package is used for publishing to PyPI.